### PR TITLE
Rename _init_extension to init_app.

### DIFF
--- a/flask_markdown/markdown.py
+++ b/flask_markdown/markdown.py
@@ -90,9 +90,9 @@ class Markdown(object):
         self._instance = md.Markdown(**markdown_options)
 
         if app is not None:
-            self._init_extension(app)
+            self.init_app(app)
 
-    def _init_extension(self, app):
+    def init_app(self, app):
         """
         Initialize with app and add as an extension.
 


### PR DESCRIPTION
This makes Flask-Markdown consistent with the factory pattern which
proposes that an extension should have an init_app() function to
allow initialisation within a factory method.